### PR TITLE
Add introductory question overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1640,17 +1640,58 @@ h1 {
   }
 }
 
+.question-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #ffcde6;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  font-family: Arial, sans-serif;
+  text-align: center;
+  color: #000;
+}
+
+.question-overlay input {
+  padding: 0.5em 1em;
+  font-size: 1em;
+  border: none;
+  border-radius: 4px;
+  margin-top: 1em;
+}
+
+.question-overlay button {
+  margin-top: 1em;
+  padding: 0.5em 1em;
+  font-size: 1em;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 
     </style>
   </head>
   <body class="container">
-    <h1 class="titulo">
-      Feliz 6 meses mi amor ❤️ <br>
-       Gracias por estos maravillosos 6 meses juntos.❤️<br> 
-      Te amo con todo mi corazón y quiero que sigamos compartiendo muchos meses y años más. Eres lo mejor que me ha pasado.</h1>
-  
-    <div class="night"></div>
-    <div class="flowers">
+    <div id="question-overlay" class="question-overlay">
+      <div>¿Cuántos meses cumplimos hoy?</div>
+      <input type="text" id="answer" />
+      <button id="submit-answer">Responder</button>
+    </div>
+
+    <div id="main-content" style="display:none;">
+      <h1 class="titulo">
+        Feliz 6 meses mi amor ❤️ <br>
+         Gracias por estos maravillosos 6 meses juntos.❤️<br>
+        Te amo con todo mi corazón y quiero que sigamos compartiendo muchos meses y años más. Eres lo mejor que me ha pasado.</h1>
+
+      <div class="night"></div>
+      <div class="flowers">
       <div class="flower flower--1">
         <div class="flower__leafs flower__leafs--1">
           <div class="flower__leaf flower__leaf--1"></div>
@@ -1959,5 +2000,17 @@ h1 {
         </div>
       </div>
     </div>
+  </div>
+  <script>
+    document.getElementById('submit-answer').addEventListener('click', function() {
+      var ans = document.getElementById('answer').value.trim();
+      if (ans === '6') {
+        document.getElementById('question-overlay').style.display = 'none';
+        document.getElementById('main-content').style.display = 'block';
+      } else {
+        alert('Respuesta incorrecta');
+      }
+    });
+  </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add CSS for question overlay in pastel pink
- insert overlay and hide main content until answered
- close wrapper and include script to reveal content when user answers `6`

## Testing
- `git status --short`
- `which tidy`

------
https://chatgpt.com/codex/tasks/task_e_6860cf8513f4832ebe02bec60c8abbe4